### PR TITLE
Stop button hover event from persisting after click

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -188,8 +188,7 @@ const ButtonComponent = React.forwardRef<
             margin: ${SCALES.mt(0)} ${SCALES.mr(0)} ${SCALES.mb(0)} ${SCALES.ml(0)};
           }
 
-          .btn:hover,
-          .btn:focus {
+          .btn:hover{
             color: ${hover.color};
             --geist-ui-button-color: ${hover.color};
             background-color: ${hover.bg};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparkl-ui",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "types": "esm/index.d.ts",


### PR DESCRIPTION
Currently - when you click a button anywhere, for example, a Like or Remix button, it remains highlighted, which is very confusing, specifically, it looks like it's "selected" in a weird way until you click somewhere else. 

We should default to buttons only looking active on hover, and not retaining this after being clicked, unless there's some exceptional case.

@deepfates I was trying to release this myself but it looks like I need some kind of npm auth token for that? Could you add the token to the 1password perhaps, and also merge this in if this sounds good?